### PR TITLE
Relative path for Cix console launchsettings

### DIFF
--- a/src/Celarix.Cix/Celarix.Cix.Console/Properties/launchSettings.json
+++ b/src/Celarix.Cix/Celarix.Cix.Console/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "Celarix.Cix.Console": {
       "commandName": "Project",
-      "commandLineArgs": "-i \"D:\\Documents\\GitHub\\IronArc\\Samples\\Assembly\\StorageTest\\StorageTest.cix\" -o \"D:\\Documents\\GitHub\\IronArc\\Samples\\Assembly\\StorageTest\\StorageTest.iasm\" -h \"D:\\Documents\\GitHub\\IronArc\\Samples\\Assembly\\StorageTest\\hardware_20210923.json\" -t -l trace"
+      "workingDirectory": "..\\..\\..\\..\\IronArc\\Samples\\Assembly\\StorageTest\\",
+      "commandLineArgs": "-i \"StorageTest.cix\" -o \"StorageTest.iasm\" -h \"hardware_20210923.json\" -t -l trace"
     }
   }
 }


### PR DESCRIPTION
Had a hardcoded a path (D:\Documents\GitHub\IronArc)

This changes to use a relative path (assumes IronArc is peer to the Cix directory).

Also specifies a working directory to be less redundant in the command line.